### PR TITLE
change default db ip to docker

### DIFF
--- a/src/Mmcc.Bot/appsettings.default.json
+++ b/src/Mmcc.Bot/appsettings.default.json
@@ -9,7 +9,7 @@
   "MySql": {
     "MySqlVersionString": "10.4.11-mariadb",
     "RetryAmount": 3,
-    "ServerIp": "172.18.0.2",
+    "ServerIp": "db",
     "Port": 3306,
     "DatabaseName": "",
     "Username": "",


### PR DESCRIPTION
This changes the default database ip in `appsettings.default.json` to use the database container name. This makes it so you do not have to keep track of database ips.