### PR TITLE
Refactors the background services to use the new PeriodicTimer

### DIFF
--- a/src/Mmcc.Bot.Polychat/Hosting/RestartNotifierBackgroundService.cs
+++ b/src/Mmcc.Bot.Polychat/Hosting/RestartNotifierBackgroundService.cs
@@ -11,17 +11,17 @@ namespace Mmcc.Bot.Polychat.Hosting;
 
 public class RestartNotifierBackgroundService : TimedBackgroundService<RestartNotifierBackgroundService>
 {
-    private const int TimeBetweenIterationsInMillis = 30 * 1000;
-
     private readonly ILogger<RestartNotifierBackgroundService> _logger;
     private readonly IMediator _mediator;
     private readonly IPolychatService _ps;
+
+    private static readonly TimeSpan TimeBetweenIterations = TimeSpan.FromSeconds(30);
 
     public RestartNotifierBackgroundService(
         ILogger<RestartNotifierBackgroundService> logger,
         IMediator mediator,
         IPolychatService ps
-    ) : base(TimeBetweenIterationsInMillis, logger)
+    ) : base(TimeBetweenIterations, logger)
     {
         _mediator = mediator;
         _ps = ps;

--- a/src/Mmcc.Bot.Polychat/Hosting/RestartNotifierBackgroundService.cs
+++ b/src/Mmcc.Bot.Polychat/Hosting/RestartNotifierBackgroundService.cs
@@ -9,16 +9,16 @@ using Mmcc.Bot.Polychat.Services;
 
 namespace Mmcc.Bot.Polychat.Hosting;
 
-public class RestartNotifierService : TimedBackgroundService<RestartNotifierService>
+public class RestartNotifierBackgroundService : TimedBackgroundService<RestartNotifierBackgroundService>
 {
     private const int TimeBetweenIterationsInMillis = 30 * 1000;
 
-    private readonly ILogger<RestartNotifierService> _logger;
+    private readonly ILogger<RestartNotifierBackgroundService> _logger;
     private readonly IMediator _mediator;
     private readonly IPolychatService _ps;
 
-    public RestartNotifierService(
-        ILogger<RestartNotifierService> logger,
+    public RestartNotifierBackgroundService(
+        ILogger<RestartNotifierBackgroundService> logger,
         IMediator mediator,
         IPolychatService ps
     ) : base(TimeBetweenIterationsInMillis, logger)

--- a/src/Mmcc.Bot.Polychat/PolychatSetup.cs
+++ b/src/Mmcc.Bot.Polychat/PolychatSetup.cs
@@ -38,7 +38,7 @@ public static class PolychatSetup
         services.AddResponder<DiscordChatMessageForwarder>();
             
         services.AddHostedService<BroadcastsHostedService>();
-        services.AddHostedService<RestartNotifierService>();
+        services.AddHostedService<RestartNotifierBackgroundService>();
 
         return services;
     }

--- a/src/Mmcc.Bot.Polychat/PolychatSetup.cs
+++ b/src/Mmcc.Bot.Polychat/PolychatSetup.cs
@@ -37,7 +37,7 @@ public static class PolychatSetup
         
         services.AddResponder<DiscordChatMessageForwarder>();
             
-        services.AddHostedService<BroadcastsHostedService>();
+        services.AddHostedService<BroadcastsBackgroundService>();
         services.AddHostedService<RestartNotifierBackgroundService>();
 
         return services;

--- a/src/Mmcc.Bot/Hosting/Moderation/ModerationBackgroundService.cs
+++ b/src/Mmcc.Bot/Hosting/Moderation/ModerationBackgroundService.cs
@@ -30,15 +30,15 @@ public class ModerationBackgroundService : TimedBackgroundService<ModerationBack
     private readonly ILogger<ModerationBackgroundService> _logger;
     private readonly IColourPalette _colourPalette;
     private readonly DiscordSettings _discordSettings;
-
-    private const int TimeBetweenIterationsInMillis = 2 * 60 * 1000;
+    
+    private static readonly TimeSpan TimeBetweenIterations = TimeSpan.FromMinutes(2);
     
     public ModerationBackgroundService(
         IServiceProvider sp,
         ILogger<ModerationBackgroundService> logger,
         IColourPalette colourPalette,
         DiscordSettings discordSettings
-    ) : base(TimeBetweenIterationsInMillis, logger)
+    ) : base(TimeBetweenIterations, logger)
     {
         _sp = sp;
         _logger = logger;


### PR DESCRIPTION
As per the title, it refactors the background services so that instead of using the archaic Task.Delay method of timing stuff it uses the brand new System.Threading.PeriodicTimer introduced in .NET 6.

Good explanation of the new timer: https://www.youtube.com/watch?v=J4JL4zR_l-0